### PR TITLE
Fix Claude CLI integration for non-interactive usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ uv run mypy src
 
 # Run all quality checks
 uv run black src tests && uv run isort src tests && uv run flake8 src tests && uv run mypy src
+
+# Pre-commit hooks (automatically run on commit)
+uv run pre-commit install
+uv run pre-commit run --all-files
 ```
 
 ## Architecture Overview
@@ -193,8 +197,10 @@ class FileCounter:
 ## Development Notes
 
 - Uses `uv` as the package manager and task runner
-- Python 3.8+ required
+- Python 3.8+ required (minimum 3.8.1 for mypy compatibility)
 - Uses dataclasses for configuration and type hints throughout
 - Rich library provides CLI formatting and progress indication
 - AI CLI tools must be installed separately (claude/gemini)
 - Prompt template in `config/prompt.txt` defines AI analysis instructions
+- Pre-commit hooks enforce code quality (black, isort, flake8, mypy)
+- Project entry point: `src:main` (can be run as `digin` command after installation)

--- a/config/default.json
+++ b/config/default.json
@@ -55,7 +55,6 @@
   "api_provider": "claude",
   "api_options": {
     "model": "claude-3-sonnet",
-    "max_tokens": 4000,
     "append_system_prompt": "只输出JSON格式，严格按照Schema定义"
   },
   "cache_enabled": true,

--- a/src/ai_client.py
+++ b/src/ai_client.py
@@ -170,7 +170,7 @@ class ClaudeClient(BaseAIClient):
         Returns:
             Claude's response
         """
-        cmd = ["claude"]
+        cmd = ["claude", "--print"]  # Use --print for non-interactive mode
         
         # Add system prompt if specified
         if "append_system_prompt" in self.api_options:
@@ -178,18 +178,21 @@ class ClaudeClient(BaseAIClient):
         
         # Add model if specified
         if "model" in self.api_options:
-            cmd.extend(["--model", self.api_options["model"]])
-        
-        # Add max tokens if specified
-        if "max_tokens" in self.api_options:
-            cmd.extend(["--max-tokens", str(self.api_options["max_tokens"])])
-        
-        # Add prompt
-        cmd.extend(["--prompt", prompt])
+            # Map common model names to valid Claude CLI model names
+            model = self.api_options["model"]
+            if model == "claude-3-sonnet":
+                model = "sonnet"
+            elif model == "claude-3-opus":
+                model = "opus"
+            elif model == "claude-3-haiku":
+                model = "haiku"
+            cmd.extend(["--model", model])
         
         try:
+            # Pass prompt via stdin instead of as argument
             result = subprocess.run(
                 cmd,
+                input=prompt,  # Pass prompt through stdin
                 capture_output=True,
                 text=True,
                 timeout=120  # 2 minute timeout


### PR DESCRIPTION
## Summary
- Fixes Claude CLI integration that was causing analysis failures
- Removes unsupported `--max-tokens` parameter
- Uses proper `--print` flag for non-interactive mode
- Passes prompts via stdin instead of command arguments
- Maps model names to valid Claude CLI aliases

## Problem
The digin tool was failing to analyze directories with the error:
```
Claude CLI failed: error: unknown option '--max-tokens'
```

## Solution
- Updated `_call_claude_cli()` method to use correct Claude CLI syntax
- Removed `max_tokens` from default configuration
- Added model name mapping (claude-3-sonnet → sonnet)
- Enhanced documentation with pre-commit hook instructions

## Test Results
✅ Successfully analyzed demo directory containing Python files  
✅ Generated complete digest.json with 95% confidence  
✅ All Claude CLI calls now work correctly

## Test plan
- [x] Test digin analysis on demo directory
- [x] Verify digest.json generation 
- [x] Confirm verbose mode shows proper output
- [x] Validate all changed files still pass linting

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Accepts common model names (claude-3-sonnet/opus/haiku), automatically mapped for CLI use.
- Refactor
  - Switched AI CLI calls to non-interactive mode with stdin-delivered prompts for more reliable execution.
- Chores
  - Removed max_tokens from configuration; backend defaults now apply.
- Documentation
  - Added pre-commit install/run commands.
  - Clarified Python requirement to >= 3.8.1.
  - Documented project entry point and enforcement of pre-commit hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->